### PR TITLE
Hotfix/build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules/
 .vscode/
 yarn.lock
 dist/
+npm-debug.log

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "start": "node dist/app.js",
+    "start": "npm run build && node dist/app.js",
     "build": "babel src --out-dir dist --source-maps",
     "dev": "nodemon src/app.js --exec ./node_modules/.bin/babel-node",
     "dev-win": "nodemon src/app.js --exec babel-node",

--- a/package.json
+++ b/package.json
@@ -4,8 +4,9 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "start": "npm run build && node dist/app.js",
-    "build": "babel src --out-dir dist --source-maps",
+    "start": "node dist/app.js",
+    "postinstall": "npm run build",
+    "build": "./node_modules/.bin/babel src --out-dir dist --source-maps",
     "dev": "nodemon src/app.js --exec ./node_modules/.bin/babel-node",
     "dev-win": "nodemon src/app.js --exec babel-node",
     "test": "mocha ./tests/ --compilers js:babel-register --recursive",

--- a/src/app.js
+++ b/src/app.js
@@ -15,7 +15,7 @@ import category from './v1/services/app/category';
 import post from './v1/services/app/post';
 
 
-const port = process.eventNames.PORT || 3000;
+const port = process.env.PORT || 3000;
 const app = express();
 
 const unless = {


### PR DESCRIPTION
https://aprendfy.herokuapp.com/health

```
(node:17) DeprecationWarning: `openSet()` is deprecated in mongoose >= 4.11.0, use `openUri()` instead, or set the `useMongoClient` option if using `connect()` or `createConnection()`. See http://mongoosejs.com/docs/connections.html#use-mongo-client
2017-07-08T22:12:43.476907+00:00 app[web.1]: Db.prototype.authenticate method will no longer be available in the next major release 3.x as MongoDB 3.6 will only allow auth against users in the admin db and will no longer allow multiple credentials on a socket. Please authenticate using MongoClient.connect with auth credentials.
```

Heroku ta reclamando disso.