### PR TITLE
New endpoint proposal

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,14 +15,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/hebertporto/feed-api.git"
+    "url": "https://github.com/Aprendfy/feed-api"
   },
-  "author": "Hebert Porto <hebertporto@gmail.com>",
-  "license": "ISC",
-  "bugs": {
-    "url": "https://github.com/hebertporto/feed-api/issues"
-  },
-  "homepage": "https://github.com/hebertporto/feed-api#readme",
   "dependencies": {
     "aws-sdk": "^2.82.0",
     "babel-runtime": "^6.23.0",
@@ -64,6 +58,7 @@
     "eslint-plugin-jsx-a11y": "5.0.1",
     "eslint-plugin-react": "7.0.1",
     "mocha": "^3.4.2",
+    "nodemon": "1.11.0",
     "pre-commit": "^1.2.2",
     "supertest": "^3.0.0"
   }

--- a/src/v1/services/app/category/index.js
+++ b/src/v1/services/app/category/index.js
@@ -2,14 +2,24 @@ import express from 'express';
 import validate from 'express-validation';
 
 import { create, update, remove, findByIdOrFindAll } from '../../../models/app/category/';
+import { getPosts } from '../../../models/app/post/';
 import {
   newCategorySchema,
   getCategorySchema,
   updateCategorySchema,
   removeCategorySchema,
+  getPostsSchema,
 } from './schema';
 
 const router = express.Router();
+
+router.get('/:categoryName/posts', validate(getPostsSchema), ({ query, params }, res, next) => {
+  const { categoryName } = params;
+  const { skip, limit } = query;
+  getPosts(categoryName, skip, limit)
+    .then(payload => res.status(200).json({ payload }))
+    .catch(error => next(error));
+});
 
 router.post('/', validate(newCategorySchema), ({ body }, res, next) => {
   create(body)

--- a/src/v1/services/app/category/schema.js
+++ b/src/v1/services/app/category/schema.js
@@ -28,3 +28,13 @@ export const removeCategorySchema = {
     categoryId: Joi.string().required(),
   },
 };
+
+export const getPostsSchema = {
+  params: {
+    categoryName: Joi.string().required(),
+  },
+  query: {
+    skip: Joi.number().min(0),
+    limit: Joi.number().min(0).max(20),
+  },
+};

--- a/tests/integration/routes/app/category.spec.js
+++ b/tests/integration/routes/app/category.spec.js
@@ -19,6 +19,23 @@ describe('INTEGRATION TESTS - CATEGORIES', () => {
       });
   });
 
+  describe('GET /v1/app/categories/:categoryName/posts', () => {
+    it('should return posts from category', (done) => {
+      const categoryName = defaultCategory.name;
+      request.get(`/v1/app/categories/${categoryName}/posts`)
+        .end((err, res) => {
+          const { payload } = res.body;
+
+          expect(res.statusCode).to.be.equal(200);
+          expect(payload).to.be.an('array');
+          expect(payload).to.satisfy(posts => posts.every(post => post.category === category));
+          expect(payload[0].author).to.be.an('object').that.has.all.keys('_id', 'name');
+
+          done(err);
+        });
+    });
+  })
+
   describe('POST /admin/user/login', () => {
     it('should return the login user', (done) => {
       const json = {


### PR DESCRIPTION
Proposing an alias from `/v1/app/posts/?category=Facebook` -> `/v1/app/categories/Facebook/posts` making our API more REST like.